### PR TITLE
Fix typo in README.md: settingj -> settings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ example: Example = load_settings(Example, nested_delimiter='_')
   necessitating the use of a mypy plugin for it to not emit type errors into
   user code.
 
-  The code recommended in their documentation for namespacing settingj, looks
+  The code recommended in their documentation for namespacing settings, looks
   like:
 
   ```python


### PR DESCRIPTION
Noticed this as I was reading through [your announcement](https://www.reddit.com/r/Python/comments/17qls0p/announcing_dataclasssettings_a_typed_settings/).