### PR TITLE
fix: Handle more class inspection subclass checks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [PEP-681](https://peps.python.org/pep-0681/)-compliant dataclass-like object,
 including but not limited to:
 
-- [Pydantic models](https://pydantic-docs.helpmanual.io/),
+- [Pydantic models](https://pydantic-docs.helpmanual.io/) (v2+),
 - [dataclasses](https://docs.python.org/3/library/dataclasses.html)
 - [attrs classes](https://www.attrs.org/en/stable/).
 

--- a/docs/source/class_compatibility.md
+++ b/docs/source/class_compatibility.md
@@ -18,6 +18,11 @@ values from the annotated types on the fields.
 
 This also applies to pydantic's `dataclasses` module.
 
+```{note}
+At this time, it **seems** as though pydantic 1.x does not retain the original
+Annotated type information, which is required to support this API.
+```
+
 ## Attrs
 
 Attrs will likely work next-best, because it has an optional `converters`, which

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dataclass-settings"
-version = "0.2.1"
+version = "0.2.2"
 description = "Declarative dataclass settings."
 
 repository = "https://github.com/dancardin/dataclass-settings"

--- a/src/dataclass_settings/class_inspect.py
+++ b/src/dataclass_settings/class_inspect.py
@@ -41,7 +41,12 @@ class ClassTypes(Enum):
         except ImportError:  # pragma: no cover
             pass
         else:
-            if isinstance(obj, type) and issubclass(obj, BaseModel):
+            try:
+                is_base_model = issubclass(obj, BaseModel)
+            except TypeError:
+                is_base_model = False
+
+            if is_base_model:
                 return cls.pydantic
 
         if hasattr(obj, "__attrs_attrs__"):


### PR DESCRIPTION
annotations like `list[int]` appear to `isinstance(list[int], type)`, but fail at `issubclass(list[int], BaseModel)`, which leads to runtime errors.