### PR TITLE
tests: empty toml for msgspec does raise error

### DIFF
--- a/src/dataclass_settings/loaders.py
+++ b/src/dataclass_settings/loaders.py
@@ -125,6 +125,6 @@ class Toml(Loader):
             try:
                 file_context = file_context[segment]
             except KeyError:
-                continue
+                return None
 
         return file_context

--- a/tests/loaders/test_toml.py
+++ b/tests/loaders/test_toml.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from pydantic import BaseModel, ValidationError
 from typing_extensions import Annotated
@@ -12,7 +14,7 @@ def test_missing_required():
         foo: Annotated[
             int,
             Toml(
-                "pyproject.toml",
+                Path(__file__).parent.parent.parent / "pyproject.toml",
                 "tool.poetry.asdf",
             ),
         ]
@@ -27,14 +29,14 @@ def test_has_required_required():
         foo: Annotated[
             str,
             Toml(
-                "pyproject.toml",
+                Path(__file__).parent.parent.parent / "pyproject.toml",
                 "tool.poetry.name",
             ),
         ]
         license: Annotated[
             str,
             Toml(
-                "pyproject.toml",
+                Path(__file__).parent.parent.parent / "pyproject.toml",
                 "tool.poetry.license",
             ),
         ]
@@ -49,7 +51,9 @@ def test_has_required_required():
 @skip_under(3, 11, reason="Requires tomllib")
 def test_missing_optional_inferred_name():
     class Config(BaseModel):
-        tool: Annotated[int, Toml("pyproject.toml")]
+        tool: Annotated[
+            int, Toml(Path(__file__).parent.parent.parent / "pyproject.toml")
+        ]
         ignoreme: str = "asdf"
 
     with pytest.raises(ValueError) as e:

--- a/tests/loaders/test_toml.py
+++ b/tests/loaders/test_toml.py
@@ -66,13 +66,15 @@ def test_missing_optional_inferred_name():
 
 
 @skip_under(3, 11, reason="Requires tomllib")
-@pytest.mark.parametrize("config_class", [BaseModel, Struct])
-def test_empty_toml(config_class, tmp_path: Path):
+@pytest.mark.parametrize(
+    "config_class, exc_class", [(BaseModel, ValidationError), (Struct, TypeError)]
+)
+def test_empty_toml(config_class, exc_class, tmp_path: Path):
     empty_toml = tmp_path / "empty.toml"
     empty_toml.write_text("")
 
     class Config(config_class):
         tool: Annotated[int, Toml(empty_toml, "tool.poetry.asdf")]
 
-    with env_setup({}), pytest.raises(ValidationError):
+    with env_setup({}), pytest.raises(exc_class):
         load_settings(Config)


### PR DESCRIPTION
I added a new test that shows a discrepency between pydantic and msgspec on a empty toml, the pydantic version raises correctly while with msgspec it doesn't.