### PR TITLE
docs: mention msgspec is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ including but not limited to:
 - [Pydantic models](https://pydantic-docs.helpmanual.io/) (v1/v2),
 - [dataclasses](https://docs.python.org/3/library/dataclasses.html)
 - [attrs classes](https://www.attrs.org/en/stable/).
+- [msgspec models](https://jcristharif.com/msgspec/).
 
 `dataclass-settings` owes its existence
 [pydantic-settings](https://github.com/pydantic/pydantic-settings), in that

--- a/docs/source/class_compatibility.md
+++ b/docs/source/class_compatibility.md
@@ -9,6 +9,7 @@ with adapters for
 [dataclasses](https://docs.python.org/3/library/dataclasses.html),
 [Pydantic](https://pydantic-docs.helpmanual.io/), and
 [attrs](https://www.attrs.org).
+[msgspec models](https://jcristharif.com/msgspec/).
 
 ## Pydantic
 
@@ -38,3 +39,7 @@ the output type can be constructed from a raw input string.
 For example, `int`, `float`, `Decimal`, `bool`, `str`, etc. For anything more
 complex, dataclasses will probably not be the most productive choice (at least
 until/if [PEP-712](https://peps.python.org/pep-0712/) is accepted/merged)
+
+## Msgspec
+Msgspec models are supported as of v0.4.0.
+


### PR DESCRIPTION
I write something very basic, the docs are explaining well the +/- between pydantic / attrs / dataclass maybe there is somehting to add on msgspec peculiarities ?