### PR TITLE
fix: Mapping error for loaders that return types other than strings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.5
 
+### 0.5.2
+
+* fix: Mapping error for loaders that return types other than strings.
+
 ### 0.5.1
 
 * fix: Closure error in nested msgspec implementation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dataclass-settings"
-version = "0.5.1"
+version = "0.5.2"
 description = "Declarative dataclass settings."
 
 repository = "https://github.com/dancardin/dataclass-settings"

--- a/src/dataclass_settings/class_inspect.py
+++ b/src/dataclass_settings/class_inspect.py
@@ -56,10 +56,10 @@ class Field:
         if not self.mapper:
             return value
 
-        if isinstance(value, str):
-            return self.mapper(value)
+        if isinstance(value, dict):
+            return self.mapper(**value)
 
-        return self.mapper(**value)
+        return self.mapper(value)
 
 
 @dataclasses.dataclass

--- a/tests/loaders/test_toml.py
+++ b/tests/loaders/test_toml.py
@@ -230,3 +230,17 @@ def test_empty_toml(config_class, exc_class, tmp_path: Path):
 
     with env_setup({}), pytest.raises(exc_class):
         load_settings(Config)
+
+
+@skip_under(3, 11, reason="Requires tomllib")
+def test_toml_int(tmp_path: Path):
+    toml_file = tmp_path / "config.toml"
+    toml_file.write_text("[postgres]\nport = 42")
+
+    class Config(Struct):
+        postgres_port: Annotated[int, Toml(toml_file, "postgres.port")]
+        postgres: Annotated[dict[str, int], Toml(toml_file, "postgres")]
+
+    config = load_settings(Config)
+    assert config.postgres_port == 42
+    assert config.postgres == {"port": 42}


### PR DESCRIPTION
Fixes https://github.com/DanCardin/dataclass-settings/issues/18
